### PR TITLE
Fix release workflow for prompts-cli and prompts-tauri

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
 
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libsoup2.4-dev
+      run: sudo apt-get update && sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libsoup2.4-dev libjavascriptcoregtk-4.1-dev
 
     - name: Check if version already published
       id: check_version

--- a/prompts-cli/Cargo.toml
+++ b/prompts-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompts-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A CLI for managing prompts for large language models."
 license = "MIT"

--- a/prompts-tauri/Cargo.toml
+++ b/prompts-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompts-tauri"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A Tauri app for managing prompts for large language models."
 license = "MIT"


### PR DESCRIPTION
This commit fixes the release workflow for `prompts-cli` and `prompts-tauri`.

The `prompts-cli` package was failing to publish because the version was not being bumped. This has been fixed by bumping the version to 0.1.1.

The `prompts-tauri` package was failing to publish because of a missing dependency in the GitHub Actions runner. This has been fixed by adding `libjavascriptcoregtk-4.1-dev` to the list of installed dependencies.