### PR TITLE
Fix(tests): Use toml crate to generate test config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -429,6 +429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +541,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +599,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -770,7 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -950,6 +972,7 @@ dependencies = [
  "tera",
  "thiserror 2.0.12",
  "tokio",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1127,6 +1150,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
  "serde",
 ]
 
@@ -1310,6 +1342,47 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -1689,6 +1762,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/prompts-cli/Cargo.toml
+++ b/prompts-cli/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.47.0", features = ["macros", "rt-multi-thread"] }
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 tempfile = "3.20.0"
+toml = "0.8.13"
 
 [[bin]]
 name = "prompts-cli"

--- a/prompts-cli/tests/cli.rs
+++ b/prompts-cli/tests/cli.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::tempdir;
+use toml::Value;
 
 fn calculate_hash(text: &str) -> String {
     let mut hasher = Sha256::new();
@@ -30,10 +31,15 @@ impl CliTestEnv {
         let prompts_storage_dir = tempdir()?;
         let prompts_storage_path = prompts_storage_dir.path().to_path_buf();
 
-        let config_content = format!(
-            "[storage]\npath = \"{}\"",
-            prompts_storage_path.to_string_lossy()
+        let mut config = toml::map::Map::new();
+        let mut storage_config = toml::map::Map::new();
+        storage_config.insert(
+            "path".to_string(),
+            Value::String(prompts_storage_path.to_string_lossy().into_owned()),
         );
+        config.insert("storage".to_string(), Value::Table(storage_config));
+
+        let config_content = toml::to_string(&config)?;
         fs::write(&config_path, config_content)?;
 
         Ok(Self {


### PR DESCRIPTION
The CLI tests were failing on Windows due to an issue with file path escaping. The temporary `config.toml` file was being generated with unescaped backslashes in the path to the prompts storage directory. This caused the TOML parser to fail with an "invalid hex escape character" error.

This commit fixes the issue by using the `toml` crate to programmatically generate the configuration content. The `toml` crate handles the necessary escaping of backslashes in the file path, ensuring that the generated `config.toml` is valid on all platforms.