### PR TITLE
fix: Trigger Test workflow on pushes to staging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - staging
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The `staging-ci.yml` workflow, which automatically updates the `Cargo.lock` file, was not being triggered because it was configured to run after the `Test` workflow completed on the `staging` branch. However, the `Test` workflow was only configured to run on pull requests.

This commit updates the `build.yml` file to also trigger the `Test` workflow on pushes to the `staging` branch. This will ensure that the `staging-ci.yml` workflow is triggered as intended, keeping the `Cargo.lock` file up-to-date automatically.