### PR TITLE
fix: Revert to cargo-release and add debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,31 +5,31 @@ on:
     branches:
       - main
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  publish-cli:
+  release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Check if version already published
-      id: check_version
+    - name: Print version before release
+      run: grep version prompts-cli/Cargo.toml
+
+    - name: Install cargo-release
+      run: cargo install cargo-release --locked
+
+    - name: Configure git
       run: |
-        CRATE_NAME=$(grep -m 1 name prompts-cli/Cargo.toml | sed -E 's/name = "([^"]+)"/\1/')
-        CRATE_VERSION=$(grep -m 1 version prompts-cli/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
-        if cargo search --limit 1 $CRATE_NAME | grep "^${CRATE_NAME} = \"${CRATE_VERSION}\""; then
-          echo "Crate version ${CRATE_VERSION} already published. Skipping publish."
-          echo "skip_publish=true" >> $GITHUB_OUTPUT
-        else
-          echo "skip_publish=false" >> $GITHUB_OUTPUT
-        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-    - name: Publish to crates.io
-      if: steps.check_version.outputs.skip_publish == 'false'
-      run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p prompts-cli
-
+    - name: Run cargo-release
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: cargo release patch --execute --no-confirm --verbose -p prompts-cli

--- a/prompts-cli/Cargo.toml
+++ b/prompts-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prompts-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "A CLI for managing prompts for large language models."
 license = "MIT"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,1 @@
+pre-release-commit-message = "chore(release): {{crate_name}} v{{version}} [skip ci]"


### PR DESCRIPTION
This commit reverts the release workflow to use `cargo-release` and adds debugging steps to help diagnose the version bumping issue.

Changes:
- Restored the `.github/workflows/release.yml` file to use `cargo-release`.
- Restored the `release.toml` file.
- Removed the `release-please` configuration files.
- Added a step to print the version from `prompts-cli/Cargo.toml` before release.
- Added the `--verbose` flag to the `cargo release` command.
- Ensured the version in `prompts-cli/Cargo.toml` is `0.1.3`.