### PR TITLE
feat: Implement save_prompt for LibSQLStorage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ This plan outlines the steps to migrate from the current file-based storage to a
     - Sub-task: The `new` function should also handle database schema creation (e.g., creating a `prompts` table).
     - Test: Write a test in `prompts-cli/tests/storage.rs` that calls `LibSQLStorage::new` and asserts that the database file is created and the `prompts` table exists.
 
-- **Task 3: Implement `save_prompt`**
+- **Task 3: Implement `save_prompt`** - **COMPLETED**
     - Test: In `prompts-cli/tests/storage.rs`, write a failing test for `save_prompt` on `LibSQLStorage`. The test should attempt to save a `Prompt` and then verify its existence directly in the database.
     - Sub-task: Implement the `save_prompt` method for `LibSQLStorage` in `prompts-cli/src/storage.rs`. This method will insert a new prompt record into the `prompts` table.
     - Sub-task: Ensure the test passes after implementation.

--- a/prompts-cli/src/core/mod.rs
+++ b/prompts-cli/src/core/mod.rs
@@ -12,26 +12,26 @@ impl Prompts {
     }
 
     pub async fn add_prompt(&self, prompt: &mut crate::storage::Prompt) -> Result<()> {
-        self.storage.save_prompt(prompt)
+        self.storage.save_prompt(prompt).await
     }
 
     pub async fn list_prompts(&self) -> Result<Vec<crate::storage::Prompt>> {
-        self.storage.load_prompts()
+        self.storage.load_prompts().await
     }
 
     pub async fn show_prompt(&self, query: &str) -> Result<Vec<crate::storage::Prompt>> {
-        let prompts = self.storage.load_prompts()?;
+        let prompts = self.storage.load_prompts().await?;
         let search_results = search_prompts(&prompts, query, &[], &[]);
         Ok(search_results)
     }
 
     pub async fn edit_prompt(&self, hash: &str, new_prompt: &mut crate::storage::Prompt) -> Result<()> {
-        self.storage.delete_prompt(hash)?;
-        self.storage.save_prompt(new_prompt)
+        self.storage.delete_prompt(hash).await?;
+        self.storage.save_prompt(new_prompt).await
     }
 
     pub async fn delete_prompt(&self, hash: &str) -> Result<()> {
-        self.storage.delete_prompt(hash)
+        self.storage.delete_prompt(hash).await
     }
 }
 

--- a/prompts-cli/tests/cli.rs
+++ b/prompts-cli/tests/cli.rs
@@ -92,13 +92,13 @@ fn test_cli_add() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_cli_list() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_cli_list() -> anyhow::Result<()> {
     let env = CliTestEnv::new()?;
     let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
 
     let mut prompt = Prompt::new("A prompt to list", Some(vec!["tagA".to_string()]), None);
-    storage.save_prompt(&mut prompt)?;
+    storage.save_prompt(&mut prompt).await?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
     cmd.arg("--config").arg(&env.config_path).arg("list");
@@ -117,13 +117,13 @@ fn test_cli_list() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_cli_show() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_cli_show() -> anyhow::Result<()> {
     let env = CliTestEnv::new()?;
     let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
 
     let mut prompt = Prompt::new("A prompt to show", None, None);
-    storage.save_prompt(&mut prompt)?;
+    storage.save_prompt(&mut prompt).await?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
     cmd.arg("--config")
@@ -138,15 +138,15 @@ fn test_cli_show() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_cli_show_multiple() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_cli_show_multiple() -> anyhow::Result<()> {
     let env = CliTestEnv::new()?;
     let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
 
     let mut prompt1 = Prompt::new("First show prompt", None, None);
-    storage.save_prompt(&mut prompt1)?;
+    storage.save_prompt(&mut prompt1).await?;
     let mut prompt2 = Prompt::new("Second show prompt", None, None);
-    storage.save_prompt(&mut prompt2)?;
+    storage.save_prompt(&mut prompt2).await?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
     cmd.arg("--config")
@@ -165,13 +165,13 @@ fn test_cli_show_multiple() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_cli_delete() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_cli_delete() -> anyhow::Result<()> {
     let env = CliTestEnv::new()?;
     let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
 
     let mut prompt = Prompt::new("A prompt to delete", None, None);
-    storage.save_prompt(&mut prompt)?;
+    storage.save_prompt(&mut prompt).await?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
     cmd.arg("--config")
@@ -192,13 +192,13 @@ fn test_cli_delete() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_cli_edit() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_cli_edit() -> anyhow::Result<()> {
     let env = CliTestEnv::new()?;
     let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
 
     let mut prompt = Prompt::new("A prompt to edit", None, None);
-    storage.save_prompt(&mut prompt)?;
+    storage.save_prompt(&mut prompt).await?;
     let old_hash = prompt.hash.clone();
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;

--- a/prompts-cli/tests/import_export.rs
+++ b/prompts-cli/tests/import_export.rs
@@ -54,8 +54,8 @@ async fn test_cli_import_export() -> anyhow::Result<()> {
 
     let storage_source =
         prompts_cli::storage::JsonStorage::new(Some(source_dir.path().to_path_buf()))?;
-    storage_source.save_prompt(&mut prompt1)?;
-    storage_source.save_prompt(&mut prompt2)?;
+    storage_source.save_prompt(&mut prompt1).await?;
+    storage_source.save_prompt(&mut prompt2).await?;
 
     // Test import
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
@@ -70,7 +70,7 @@ async fn test_cli_import_export() -> anyhow::Result<()> {
 
     // Verify imported prompts
     let storage_dest = prompts_cli::storage::JsonStorage::new(Some(env.storage_path.clone()))?;
-    let loaded_prompts = storage_dest.load_prompts()?;
+    let loaded_prompts = storage_dest.load_prompts().await?;
     assert_eq!(loaded_prompts.len(), 2);
     assert!(loaded_prompts
         .iter()

--- a/prompts-cli/tests/storage.rs
+++ b/prompts-cli/tests/storage.rs
@@ -3,7 +3,7 @@ use prompts_cli::{
     storage::{Storage, JsonStorage, LibSQLStorage}
 };
 use tempfile::tempdir;
-use libsql::Builder;
+use libsql::{Builder, Value};
 
 #[tokio::test]
 async fn test_libsql_storage_new() -> anyhow::Result<()> {
@@ -22,29 +22,54 @@ async fn test_libsql_storage_new() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_json_storage() -> anyhow::Result<()> {
+#[tokio::test]
+async fn test_libsql_save_prompt() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let db_path = dir.path().join("test.db");
+    let storage = LibSQLStorage::new(Some(db_path.clone())).await?;
+
+    let mut prompt = Prompt::new("test content", Some(vec!["tag1".to_string()]), None);
+    storage.save_prompt(&mut prompt).await?;
+
+    let db = Builder::new_local(db_path.to_str().unwrap()).build().await?;
+    let conn = db.connect()?;
+    let mut rows = conn.query("SELECT content, tags, categories, hash FROM prompts WHERE hash = ?", vec![Value::from(prompt.hash.clone())]).await?;
+
+    let row = rows.next().await?.unwrap();
+    let content: String = row.get(0)?;
+    let tags: String = row.get(1)?;
+    let hash: String = row.get(3)?;
+
+    assert_eq!(content, "test content");
+    assert_eq!(tags, "[\"tag1\"]");
+    assert_eq!(hash, prompt.hash);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_json_storage() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let storage_path = dir.path().to_path_buf();
     let storage = JsonStorage::new(Some(storage_path.clone()))?;
 
     // Test saving a prompt
     let mut prompt = Prompt::new("test content", Some(vec!["tag1".to_string()]), None);
-    storage.save_prompt(&mut prompt)?;
+    storage.save_prompt(&mut prompt).await?;
     assert!(!prompt.hash.is_empty());
     let prompt_file = storage_path.join(format!("{}.json", prompt.hash));
     assert!(prompt_file.exists());
 
     // Test loading prompts
-    let loaded_prompts = storage.load_prompts()?;
+    let loaded_prompts = storage.load_prompts().await?;
     assert_eq!(loaded_prompts.len(), 1);
     assert_eq!(loaded_prompts[0].content, "test content");
     assert_eq!(loaded_prompts[0].tags, Some(vec!["tag1".to_string()]));
 
     // Test deleting a prompt
-    storage.delete_prompt(&prompt.hash)?;
+    storage.delete_prompt(&prompt.hash).await?;
     assert!(!prompt_file.exists());
-    let loaded_prompts_after_delete = storage.load_prompts()?;
+    let loaded_prompts_after_delete = storage.load_prompts().await?;
     assert!(loaded_prompts_after_delete.is_empty());
 
     Ok(())


### PR DESCRIPTION
I have implemented the `save_prompt` method for the `LibSQLStorage` backend.

Following a Test-Driven Development approach, I first added a test to verify the functionality of saving a prompt to the database.

To support the async nature of the `libsql` crate, I converted the `Storage` trait to be async using `async-trait`. This required me to update the `JsonStorage` implementation and all related tests to be async.

The `save_prompt` method for `LibSQLStorage` serializes the `tags` and `categories` vectors into JSON strings before storing them in the database.