### PR TITLE
feat: Integrate LibSQLStorage into the application

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ This plan outlines the steps to migrate from the current file-based storage to a
     - Sub-task: Implement the `delete_prompt` method for `LibSQLStorage`. This method will delete a prompt from the `prompts` table based on its hash.
     - Sub-task: Ensure the test passes after implementation.
 
-- **Task 6: Integrate `LibSQLStorage` into the application**
+- **Task 6: Integrate `LibSQLStorage` into the application** - **COMPLETED**
     - Sub-task: Modify the application's entry point (likely in `prompts-cli/src/main.rs` and `prompts-cli/src/lib.rs`) to use `LibSQLStorage` instead of `JsonStorage`.
     - Sub-task: This may involve adding a configuration option to `config.rs` to allow the user to select the storage backend and specify the database path. For now, a direct replacement is sufficient to prove the concept.
     - Test: Manually run the CLI to ensure all commands (`add`, `list`, `show`, `edit`, `delete`) work correctly with the new `LibSQLStorage` backend. Existing integration tests should be adapted and should all pass.

--- a/prompts-cli/Cargo.toml
+++ b/prompts-cli/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.141"
 sha2 = "0.10.9"
 thiserror = "2.0.12"
 tokio = { version = "1.47.0", features = ["macros", "rt-multi-thread"] }
-libsql = { version = "0.9.19", features = ["replication"] }
+libsql = { version = "0.9.19", features = ["replication", "serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/prompts-cli/src/lib.rs
+++ b/prompts-cli/src/lib.rs
@@ -2,4 +2,4 @@ pub mod core;
 pub mod storage;
 
 pub use crate::core::{Prompts, search_prompts};
-pub use crate::storage::{Storage, JsonStorage, Prompt};
+pub use crate::storage::{Storage, JsonStorage, LibSQLStorage, Prompt};

--- a/prompts-cli/tests/cli.rs
+++ b/prompts-cli/tests/cli.rs
@@ -1,6 +1,6 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
-use prompts_cli::{Prompt, storage::{JsonStorage, Storage}};
+use prompts_cli::{Prompt, storage::{JsonStorage, LibSQLStorage, Storage}};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
@@ -19,23 +19,28 @@ use tempfile::TempDir;
 struct CliTestEnv {
     _config_dir: TempDir,
     config_path: PathBuf,
-    _prompts_storage_dir: TempDir,
+    _storage_temp: TempDir,
     storage_path: PathBuf,
 }
 
 impl CliTestEnv {
-    fn new() -> anyhow::Result<Self> {
+    fn new(storage_type: &str) -> anyhow::Result<Self> {
         let config_dir = tempdir()?;
         let config_path = config_dir.path().join("config.toml");
 
-        let prompts_storage_dir = tempdir()?;
-        let prompts_storage_path = prompts_storage_dir.path().to_path_buf();
+        let storage_temp = tempdir()?;
+        let storage_path = if storage_type == "json" {
+            storage_temp.path().to_path_buf()
+        } else {
+            storage_temp.path().join("test.db")
+        };
 
         let mut config = toml::map::Map::new();
         let mut storage_config = toml::map::Map::new();
+        storage_config.insert("type".to_string(), Value::String(storage_type.to_string()));
         storage_config.insert(
             "path".to_string(),
-            Value::String(prompts_storage_path.to_string_lossy().into_owned()),
+            Value::String(storage_path.to_string_lossy().into_owned()),
         );
         config.insert("storage".to_string(), Value::Table(storage_config));
 
@@ -45,16 +50,15 @@ impl CliTestEnv {
         Ok(Self {
             _config_dir: config_dir,
             config_path,
-            _prompts_storage_dir: prompts_storage_dir,
-            storage_path: prompts_storage_path,
+            _storage_temp: storage_temp,
+            storage_path,
         })
     }
 }
 
 
-#[test]
-fn test_cli_add() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
+async fn test_cli_add_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
     cmd.arg("--config")
@@ -74,28 +78,55 @@ fn test_cli_add() -> anyhow::Result<()> {
             &expected_hash[..12]
         )));
 
-    let prompt_path = env.storage_path.join(format!("{}.json", expected_hash));
-    assert!(prompt_path.exists());
-
-    let content = fs::read_to_string(prompt_path)?;
-    let prompt: Prompt = serde_json::from_str(&content)?;
-    assert_eq!(prompt.content, "This is a new prompt.");
-    assert_eq!(
-        prompt.tags,
-        Some(vec!["tag1".to_string(), "tag2".to_string()])
-    );
-    assert_eq!(
-        prompt.categories,
-        Some(vec!["cat1".to_string(), "cat2".to_string()])
-    );
+    if storage_type == "json" {
+        let prompt_path = env.storage_path.join(format!("{}.json", expected_hash));
+        assert!(prompt_path.exists());
+        let content = fs::read_to_string(prompt_path)?;
+        let prompt: Prompt = serde_json::from_str(&content)?;
+        assert_eq!(prompt.content, "This is a new prompt.");
+        assert_eq!(
+            prompt.tags,
+            Some(vec!["tag1".to_string(), "tag2".to_string()])
+        );
+        assert_eq!(
+            prompt.categories,
+            Some(vec!["cat1".to_string(), "cat2".to_string()])
+        );
+    } else {
+        let storage = prompts_cli::storage::LibSQLStorage::new(Some(env.storage_path)).await?;
+        let prompts = storage.load_prompts().await?;
+        let prompt = prompts.iter().find(|p| p.hash == expected_hash).unwrap();
+        assert_eq!(prompt.content, "This is a new prompt.");
+        assert_eq!(
+            prompt.tags,
+            Some(vec!["tag1".to_string(), "tag2".to_string()])
+        );
+        assert_eq!(
+            prompt.categories,
+            Some(vec!["cat1".to_string(), "cat2".to_string()])
+        );
+    }
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_cli_list() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
-    let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
+async fn test_cli_add_json() -> anyhow::Result<()> {
+    test_cli_add_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_add_libsql() -> anyhow::Result<()> {
+    test_cli_add_impl("libsql").await
+}
+
+async fn test_cli_list_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
 
     let mut prompt = Prompt::new("A prompt to list", Some(vec!["tagA".to_string()]), None);
     storage.save_prompt(&mut prompt).await?;
@@ -110,17 +141,26 @@ async fn test_cli_list() -> anyhow::Result<()> {
             &prompt.hash[..12]
         )));
 
-    
-
-    
-
     Ok(())
 }
 
 #[tokio::test]
-async fn test_cli_show() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
-    let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
+async fn test_cli_list_json() -> anyhow::Result<()> {
+    test_cli_list_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_list_libsql() -> anyhow::Result<()> {
+    test_cli_list_impl("libsql").await
+}
+
+async fn test_cli_show_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
 
     let mut prompt = Prompt::new("A prompt to show", None, None);
     storage.save_prompt(&mut prompt).await?;
@@ -139,9 +179,22 @@ async fn test_cli_show() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_cli_show_multiple() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
-    let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
+async fn test_cli_show_json() -> anyhow::Result<()> {
+    test_cli_show_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_show_libsql() -> anyhow::Result<()> {
+    test_cli_show_impl("libsql").await
+}
+
+async fn test_cli_show_multiple_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
 
     let mut prompt1 = Prompt::new("First show prompt", None, None);
     storage.save_prompt(&mut prompt1).await?;
@@ -166,11 +219,25 @@ async fn test_cli_show_multiple() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_cli_delete() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
-    let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
+async fn test_cli_show_multiple_json() -> anyhow::Result<()> {
+    test_cli_show_multiple_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_show_multiple_libsql() -> anyhow::Result<()> {
+    test_cli_show_multiple_impl("libsql").await
+}
+
+async fn test_cli_delete_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
 
     let mut prompt = Prompt::new("A prompt to delete", None, None);
+    let prompt_hash = prompt.hash.clone();
     storage.save_prompt(&mut prompt).await?;
 
     let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
@@ -186,16 +253,35 @@ async fn test_cli_delete() -> anyhow::Result<()> {
             &prompt.hash[..12]
         )));
 
-    let prompt_path = env.storage_path.join(format!("{}.json", prompt.hash));
-    assert!(!prompt_path.exists());
+    if storage_type == "json" {
+        let prompt_path = env.storage_path.join(format!("{}.json", prompt.hash));
+        assert!(!prompt_path.exists());
+    } else {
+        let prompts = storage.load_prompts().await?;
+        assert!(prompts.iter().find(|p| p.hash == prompt_hash).is_none());
+    }
+
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_cli_edit() -> anyhow::Result<()> {
-    let env = CliTestEnv::new()?;
-    let storage = JsonStorage::new(Some(env.storage_path.to_path_buf()))?;
+async fn test_cli_delete_json() -> anyhow::Result<()> {
+    test_cli_delete_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_delete_libsql() -> anyhow::Result<()> {
+    test_cli_delete_impl("libsql").await
+}
+
+async fn test_cli_edit_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
 
     let mut prompt = Prompt::new("A prompt to edit", None, None);
     storage.save_prompt(&mut prompt).await?;
@@ -220,19 +306,39 @@ async fn test_cli_edit() -> anyhow::Result<()> {
             &new_hash[..12]
         )));
 
-    let old_prompt_path = env.storage_path.join(format!("{}.json", old_hash));
-    assert!(!old_prompt_path.exists());
-    let new_prompt_path = env.storage_path.join(format!("{}.json", new_hash));
-    assert!(new_prompt_path.exists());
+    if storage_type == "json" {
+        let old_prompt_path = env.storage_path.join(format!("{}.json", old_hash));
+        assert!(!old_prompt_path.exists());
+        let new_prompt_path = env.storage_path.join(format!("{}.json", new_hash));
+        assert!(new_prompt_path.exists());
 
-    let content = fs::read_to_string(new_prompt_path)?;
-    let edited_prompt: Prompt = serde_json::from_str(&content)?;
-    assert_eq!(edited_prompt.content, "An edited prompt");
-    assert_eq!(
-        edited_prompt.tags,
-        Some(vec!["newtag1".to_string(), "newtag2".to_string()])
-    );
+        let content = fs::read_to_string(new_prompt_path)?;
+        let edited_prompt: Prompt = serde_json::from_str(&content)?;
+        assert_eq!(edited_prompt.content, "An edited prompt");
+        assert_eq!(
+            edited_prompt.tags,
+            Some(vec!["newtag1".to_string(), "newtag2".to_string()])
+        );
+    } else {
+        let prompts = storage.load_prompts().await?;
+        assert!(prompts.iter().find(|p| p.hash == old_hash).is_none());
+        let edited_prompt = prompts.iter().find(|p| p.hash == new_hash).unwrap();
+        assert_eq!(edited_prompt.content, "An edited prompt");
+        assert_eq!(
+            edited_prompt.tags,
+            Some(vec!["newtag1".to_string(), "newtag2".to_string()])
+        );
+    }
 
     Ok(())
 }
 
+#[tokio::test]
+async fn test_cli_edit_json() -> anyhow::Result<()> {
+    test_cli_edit_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_edit_libsql() -> anyhow::Result<()> {
+    test_cli_edit_impl("libsql").await
+}


### PR DESCRIPTION
This commit integrates `LibSQLStorage` as a configurable storage backend for the prompts-cli application.

The following changes were made:
- Added a `type` field to the `storage` section of the configuration file to allow selecting between `json` and `libsql` backends. The default is `json` for backward compatibility.
- Modified `main.rs` to dynamically instantiate the selected storage backend.
- Adapted the integration tests in `tests/cli.rs` to run against both `JsonStorage` and `LibSQLStorage`, ensuring that all commands work correctly with both backends.
- Updated `TODO.md` to mark the integration task as complete.