### PR TITLE
Refactor and document storage implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@ This plan outlines the steps to migrate from the current file-based storage to a
     - Sub-task: This may involve adding a configuration option to `config.rs` to allow the user to select the storage backend and specify the database path. For now, a direct replacement is sufficient to prove the concept.
     - Test: Manually run the CLI to ensure all commands (`add`, `list`, `show`, `edit`, `delete`) work correctly with the new `LibSQLStorage` backend. Existing integration tests should be adapted and should all pass.
 
-- **Task 7: Refactor and clean up**
+- **Task 7: Refactor and clean up** - **COMPLETED**
     - Sub-task: Remove the `JsonStorage` implementation if it's no longer needed, or keep it as an alternative backend.
     - Sub-task: Review the code for any necessary refactoring and add documentation for the new storage implementation.
 

--- a/prompts-cli/src/storage.rs
+++ b/prompts-cli/src/storage.rs
@@ -6,16 +6,25 @@ use serde::{Serialize, Deserialize};
 use std::path::PathBuf;
 use libsql::Connection;
 use libsql::Builder;
+use std::fs;
 
+/// Represents a prompt with its content, metadata, and a unique hash.
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Prompt {
+    /// The text content of the prompt.
     pub content: String,
+    /// Optional tags associated with the prompt.
     pub tags: Option<Vec<String>>,
+    /// Optional categories for grouping prompts.
     pub categories: Option<Vec<String>>,
+    /// A unique SHA256 hash of the prompt's content, used for identification.
     pub hash: String,
 }
 
 impl Prompt {
+    /// Creates a new `Prompt` instance.
+    ///
+    /// The `hash` is automatically generated from the content.
     pub fn new(content: &str, tags: Option<Vec<String>>, categories: Option<Vec<String>>) -> Self {
         let hash = Sha256::digest(content.as_bytes());
         Self {
@@ -27,26 +36,44 @@ impl Prompt {
     }
 }
 
+/// A trait defining the interface for prompt storage.
 #[async_trait]
 pub trait Storage {
+    /// Saves a prompt to the storage.
     async fn save_prompt(&self, prompt: &mut Prompt) -> Result<()>;
+    /// Loads all prompts from the storage.
     async fn load_prompts(&self) -> Result<Vec<Prompt>>;
+    /// Deletes a prompt from the storage by its hash.
     async fn delete_prompt(&self, hash: &str) -> Result<()>;
 }
 
+/// A storage implementation that uses JSON files.
+///
+/// Each prompt is stored as a separate JSON file in a specified directory.
 pub struct JsonStorage {
     storage_path: PathBuf,
 }
 
+/// Returns the default storage directory for the application.
+///
+/// This is typically `~/.config/prompts-cli`.
+fn get_default_storage_dir() -> Result<PathBuf> {
+    let mut path = dirs::config_dir().ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?;
+    path.push("prompts-cli");
+    Ok(path)
+}
+
 impl JsonStorage {
+    /// Creates a new `JsonStorage` instance.
+    ///
+    /// If `storage_path` is `None`, a default directory is used.
     pub fn new(storage_path: Option<PathBuf>) -> Result<Self> {
         let path = match storage_path {
             Some(path) => path,
             None => {
-                let mut default_path = dirs::config_dir().ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?;
-                default_path.push("prompts-cli");
+                let mut default_path = get_default_storage_dir()?;
                 default_path.push("prompts");
-                std::fs::create_dir_all(&default_path)?;
+                fs::create_dir_all(&default_path)?;
                 default_path
             }
         };
@@ -86,19 +113,26 @@ impl Storage for JsonStorage {
     }
 }
 
+/// A storage implementation that uses a LibSQL database.
+///
+/// All prompts are stored in a single database file.
 pub struct LibSQLStorage {
     conn: Connection,
 }
 
 impl LibSQLStorage {
+    /// Creates a new `LibSQLStorage` instance.
+    ///
+    /// If `storage_path` is `None`, a default database file is used.
+    /// This will also create the necessary tables if they don't exist.
     pub async fn new(storage_path: Option<PathBuf>) -> Result<Self> {
         let db_path = match storage_path {
             Some(path) => path,
             None => {
-                let mut default_path = dirs::config_dir().ok_or_else(|| anyhow::anyhow!("Could not find config directory"))?;
-                default_path.push("prompts-cli");
-                default_path.push("prompts.db");
-                default_path
+                let mut path = get_default_storage_dir()?;
+                fs::create_dir_all(&path)?;
+                path.push("prompts.db");
+                path
             }
         };
 
@@ -122,8 +156,8 @@ impl LibSQLStorage {
 #[async_trait]
 impl Storage for LibSQLStorage {
     async fn save_prompt(&self, prompt: &mut Prompt) -> Result<()> {
-        let tags = prompt.tags.as_ref().map_or(Ok(None), |t| serde_json::to_string(t).map(Some))?.unwrap_or("[]".to_string());
-        let categories = prompt.categories.as_ref().map_or(Ok(None), |c| serde_json::to_string(c).map(Some))?.unwrap_or("[]".to_string());
+        let tags = serde_json::to_string(&prompt.tags.as_deref().unwrap_or_default())?;
+        let categories = serde_json::to_string(&prompt.categories.as_deref().unwrap_or_default())?;
 
         self.conn.execute(
             "INSERT INTO prompts (hash, content, tags, categories) VALUES (?1, ?2, ?3, ?4)",


### PR DESCRIPTION
This commit refactors the storage implementation in `prompts-cli/src/storage.rs` to improve code clarity and reduce duplication. It also adds documentation to the storage-related structs and traits.

- Extracted common logic for getting the default storage directory into a helper function.
- Simplified JSON serialization in `LibSQLStorage::save_prompt`.
- Added doc comments to `Prompt`, `Storage`, `JsonStorage`, and `LibSQLStorage`.
- Updated `TODO.md` to mark the refactoring task as complete.