### PR TITLE
feat: Add tag-based filtering to the list command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,9 +33,9 @@ This document outlines the next steps for the `prompts-cli` project, focusing on
 
 ### **US-009: Complete the Tagging Feature**
 
--   **Task:** Add tag-based filtering to the `list` command.
-    -   **Sub-task:** Add a `--tag` option to the `list` command in `main.rs`.
-    -   **Sub-task:** Update `Prompts::list_prompts` to accept and pass tag filters to `search_prompts`.
+-   **Task:** Add tag-based filtering to the `list` command. (Done)
+    -   **Sub-task:** Add a `--tag` option to the `list` command in `main.rs`. (Done)
+    -   **Sub-task:** Update `Prompts::list_prompts` to accept and pass tag filters to `search_prompts`. (Done)
 -   **Task:** Ensure all search-based commands can filter by tag.
     -   **Sub-task:** Modify `Prompts::show_prompt` and other relevant functions to accept and use tag/category filters.
 

--- a/prompts-cli/src/core/mod.rs
+++ b/prompts-cli/src/core/mod.rs
@@ -20,8 +20,14 @@ impl Prompts {
         Ok(true)
     }
 
-    pub async fn list_prompts(&self) -> Result<Vec<crate::storage::Prompt>> {
-        self.storage.load_prompts().await
+    pub async fn list_prompts(&self, tags: Option<Vec<String>>) -> Result<Vec<crate::storage::Prompt>> {
+        let prompts = self.storage.load_prompts().await?;
+        if let Some(tags) = tags {
+            let search_results = search_prompts(&prompts, "", &tags, &[]);
+            Ok(search_results)
+        } else {
+            Ok(prompts)
+        }
     }
 
     pub async fn show_prompt(&self, query: &str) -> Result<Vec<crate::storage::Prompt>> {

--- a/prompts-cli/tests/cli.rs
+++ b/prompts-cli/tests/cli.rs
@@ -190,6 +190,45 @@ async fn test_cli_list_libsql() -> anyhow::Result<()> {
     test_cli_list_impl("libsql").await
 }
 
+async fn test_cli_list_with_tag_filter_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+    let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {
+        Box::new(JsonStorage::new(Some(env.storage_path.to_path_buf()))?)
+    } else {
+        Box::new(LibSQLStorage::new(Some(env.storage_path.to_path_buf())).await?)
+    };
+
+    let mut prompt1 = Prompt::new("A prompt with tag", Some(vec!["test-tag".to_string()]), None);
+    storage.save_prompt(&mut prompt1).await?;
+
+    let mut prompt2 = Prompt::new("A prompt without tag", None, None);
+    storage.save_prompt(&mut prompt2).await?;
+
+    let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
+    cmd.arg("--config")
+        .arg(&env.config_path)
+        .arg("list")
+        .arg("--tags")
+        .arg("test-tag");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("A prompt with tag"))
+        .stdout(predicate::str::contains("A prompt without tag").not());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_list_with_tag_filter_json() -> anyhow::Result<()> {
+    test_cli_list_with_tag_filter_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_list_with_tag_filter_libsql() -> anyhow::Result<()> {
+    test_cli_list_with_tag_filter_impl("libsql").await
+}
+
 async fn test_cli_show_impl(storage_type: &str) -> anyhow::Result<()> {
     let env = CliTestEnv::new(storage_type)?;
     let storage: Box<dyn Storage + Send + Sync> = if storage_type == "json" {

--- a/prompts-cli/tests/prompts_api.rs
+++ b/prompts-cli/tests/prompts_api.rs
@@ -19,7 +19,7 @@ async fn test_prompts_api() -> anyhow::Result<()> {
     assert!(!prompt.hash.is_empty());
 
     // Test listing prompts
-    let listed_prompts = prompts_api.list_prompts().await?;
+    let listed_prompts = prompts_api.list_prompts(None).await?;
     assert_eq!(listed_prompts.len(), 1);
     assert_eq!(listed_prompts[0].content, "test content");
 
@@ -31,14 +31,14 @@ async fn test_prompts_api() -> anyhow::Result<()> {
     // Test editing a prompt
     let mut edited_prompt = Prompt::new("edited content", Some(vec!["tag2".to_string()]), None);
     prompts_api.edit_prompt(&prompt.hash, &mut edited_prompt).await?;
-    let updated_prompts = prompts_api.list_prompts().await?;
+    let updated_prompts = prompts_api.list_prompts(None).await?;
     assert_eq!(updated_prompts.len(), 1);
     assert_eq!(updated_prompts[0].content, "edited content");
     assert_eq!(updated_prompts[0].tags, Some(vec!["tag2".to_string()]));
 
     // Test deleting a prompt
     prompts_api.delete_prompt(&updated_prompts[0].hash).await?;
-    let remaining_prompts = prompts_api.list_prompts().await?;
+    let remaining_prompts = prompts_api.list_prompts(None).await?;
     assert!(remaining_prompts.is_empty());
 
     Ok(())
@@ -62,7 +62,7 @@ async fn test_add_duplicate_prompt() -> anyhow::Result<()> {
     assert!(!added_again);
 
     // Verify that only one prompt exists
-    let listed_prompts = prompts_api.list_prompts().await?;
+    let listed_prompts = prompts_api.list_prompts(None).await?;
     assert_eq!(listed_prompts.len(), 1);
 
     Ok(())


### PR DESCRIPTION
This commit implements tag-based filtering for the `list` command.

- Adds a `--tags` option to the `list` command in `main.rs`.
- Updates `Prompts::list_prompts` to accept and filter by tags.
- Adds an integration test to verify the new functionality.
- Updates `TODO.md` to reflect the completion of this task.