### PR TITLE
refactor(edit): Move edit logic to core library

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,11 +39,11 @@ This document outlines the next steps for the `prompts-cli` project, focusing on
 -   **Task:** Ensure all search-based commands can filter by tag.
     -   **Sub-task:** Modify `Prompts::show_prompt` and other relevant functions to accept and use tag/category filters. (Done)
 
-### **Improve `edit` Command Ergonomics**
+### **Improve `edit` Command Ergonomics (Completed)**
 
--   **Task:** Refactor the `edit` command to merge changes instead of requiring full re-specification.
-    -   **Sub-task:** Fetch the existing prompt's metadata (tags, categories).
-    -   **Sub-task:** Allow users to add or remove specific tags without re-entering the entire list.
+-   **Task:** Refactor the `edit` command to merge changes instead of requiring full re-specification. (Done)
+    -   **Sub-task:** Fetch the existing prompt's metadata (tags, categories). (Done)
+    -   **Sub-task:** Allow users to add or remove specific tags without re-entering the entire list. (Done)
 
 ---
 


### PR DESCRIPTION
This commit refactors the `edit` command to move the business logic for merging tags and categories from the CLI layer (`main.rs`) into the core `Prompts` API (`prompts-cli/src/core/mod.rs`).

The `Prompts::edit_prompt` function now accepts optional arguments for adding/removing tags and categories, and for updating the prompt text. It handles the logic of fetching the existing prompt, merging the changes, and saving the updated prompt.

The CLI has been updated to use this new function, resulting in a cleaner implementation and better separation of concerns.

The `--tags` and `--categories` flags have been removed from the `edit` command in favor of the more ergonomic `--add-tags`, `--remove-tags`, `--add-categories`, and `--remove-categories` flags.

All related tests have been updated to reflect these changes.