### PR TITLE
feat(tests): add integration tests for failure cases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,5 +57,6 @@ This document outlines the next steps for the `prompts-cli` project, focusing on
 
 ### **Enhance Test Coverage**
 
--   **Task:** Add integration tests for failure cases identified in `EVAL.md`.
+-   **Task:** Add integration tests for failure cases.
+    -   **Sub-task:** Add tests for editing, deleting, and showing non-existent prompts. (Done)
     -   **Test:** Add tests for the new features as they are developed.

--- a/prompts-cli/tests/cli.rs
+++ b/prompts-cli/tests/cli.rs
@@ -743,3 +743,83 @@ async fn test_cli_show_with_tag_filter_json() -> anyhow::Result<()> {
 async fn test_cli_show_with_tag_filter_libsql() -> anyhow::Result<()> {
     test_cli_show_with_tag_filter_impl("libsql").await
 }
+
+async fn test_cli_edit_non_existent_prompt_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+
+    let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
+    cmd.arg("--config")
+        .arg(&env.config_path)
+        .arg("edit")
+        .arg("a prompt that does not exist")
+        .arg("--text")
+        .arg("new text");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("[]"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_edit_non_existent_prompt_json() -> anyhow::Result<()> {
+    test_cli_edit_non_existent_prompt_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_edit_non_existent_prompt_libsql() -> anyhow::Result<()> {
+    test_cli_edit_non_existent_prompt_impl("libsql").await
+}
+
+async fn test_cli_delete_non_existent_prompt_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+
+    let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
+    cmd.arg("--config")
+        .arg(&env.config_path)
+        .arg("delete")
+        .arg("a prompt that does not exist");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("[]"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_delete_non_existent_prompt_json() -> anyhow::Result<()> {
+    test_cli_delete_non_existent_prompt_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_delete_non_existent_prompt_libsql() -> anyhow::Result<()> {
+    test_cli_delete_non_existent_prompt_impl("libsql").await
+}
+
+async fn test_cli_show_non_existent_prompt_impl(storage_type: &str) -> anyhow::Result<()> {
+    let env = CliTestEnv::new(storage_type)?;
+
+    let mut cmd = Command::cargo_bin(r#"prompts-cli"#)?;
+    cmd.arg("--config")
+        .arg(&env.config_path)
+        .arg("show")
+        .arg("a prompt that does not exist");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("[]"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cli_show_non_existent_prompt_json() -> anyhow::Result<()> {
+    test_cli_show_non_existent_prompt_impl("json").await
+}
+
+#[tokio::test]
+async fn test_cli_show_non_existent_prompt_libsql() -> anyhow::Result<()> {
+    test_cli_show_non_existent_prompt_impl("libsql").await
+}


### PR DESCRIPTION
This commit adds integration tests for several failure cases to improve the robustness of the CLI.

The following scenarios are now tested:
- `edit` command with a query that matches no prompts
- `delete` command with a query that matches no prompts
- `show` command with a query that matches no prompts

These tests assert that the CLI exits successfully and provides an empty JSON array as output, indicating that no prompts were found, which is the expected behavior for non-interactive use.